### PR TITLE
Allow private / protected callback declarations

### DIFF
--- a/lib/audited/auditor.rb
+++ b/lib/audited/auditor.rb
@@ -70,8 +70,8 @@ module Audited
         # to notify a party after the audit has been created or if you want to access the newly-created
         # audit.
         define_callbacks :audit
-        set_callback :audit, :after, :after_audit, if: lambda { self.respond_to?(:after_audit) }
-        set_callback :audit, :around, :around_audit, if: lambda { self.respond_to?(:around_audit) }
+        set_callback :audit, :after, :after_audit, if: lambda { self.respond_to?(:after_audit, true) }
+        set_callback :audit, :around, :around_audit, if: lambda { self.respond_to?(:around_audit, true) }
 
         attr_accessor :version
 

--- a/spec/support/active_record/models.rb
+++ b/spec/support/active_record/models.rb
@@ -40,6 +40,8 @@ module Models
       audited
       attr_accessor :bogus_attr, :around_attr
 
+      private
+
       def after_audit
         self.bogus_attr = "do something"
       end


### PR DESCRIPTION
Prior to this change, users would have to declare publicly scoped
callback handlers.